### PR TITLE
Use separate Dex clients for each actual client

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -210,7 +210,7 @@ func Auth(authRequest AuthRequest) (AuthResponse, error) {
 	authRequest.verifier = provider.Verifier(&oidc.Config{ClientID: authRequest.ClientID})
 
 	// Setup complete, start the actual auth
-	authRequest.scopes = []string{"openid", "profile", "email", "offline_access", "groups"}
+	authRequest.scopes = []string{"openid", "profile", "email", "offline_access", "groups", "audience:server:client_id:kubernetes"}
 	authCodeURL := oauth2Config(authRequest).AuthCodeURL("", oauth2.AccessTypeOffline)
 
 	resp, err := client.Get(authCodeURL)


### PR DESCRIPTION
Previously Velum, CaaSP CLI, and Kubernetes all shared a single Dex
client. From a security perspective, this was far from ideal.

Update CaaSP CLI to request a token which is valid for the Kubernetes
client.

Depends-On: https://github.com/kubic-project/salt/pull/380
Depends-On: https://github.com/kubic-project/velum/pull/439